### PR TITLE
Speed up simulations by using a custom copy method

### DIFF
--- a/chipwizard_sim/models.py
+++ b/chipwizard_sim/models.py
@@ -230,6 +230,14 @@ class LayerCellState:
     powered: bool = False
     open: bool = True
 
+    def copy(self):
+        return LayerCellState(
+            self.exists,
+            self.connections,  # reuse connections
+            self.powered,
+            self.open,
+        )
+
     def __bool__(self):
         return self.exists
 
@@ -251,6 +259,16 @@ class CellState:
     via: bool
 
     n_on_top: bool
+
+    def copy(self):
+        return CellState(
+            self.metal.copy(),
+            self.ntype.copy(),
+            self.ptype.copy(),
+            self.capacitor,
+            self.via,
+            self.n_on_top,
+        )
 
     def is_transistor(self):
         return self.ntype and self.ptype
@@ -297,6 +315,15 @@ class SignalState:
     input_value: bool = False
     output_value: bool = False
 
+    def copy(self):
+        return SignalState(
+            self.name,
+            self.type,
+            self.connections,  # reuse connections
+            self.input_value,
+            self.output_value,
+        )
+
     @classmethod
     def from_signal(cls, signal: Signal) -> SignalState:
         return SignalState(signal.name, signal.type, set())
@@ -306,6 +333,12 @@ class SignalState:
 class State:
     cells: dict[Coords, CellState]
     signals: dict[Coords, SignalState]
+
+    def copy(self):
+        return State(
+            {loc: cs.copy() for loc, cs in self.cells.items()},
+            {loc: ss.copy() for loc, ss in self.signals.items()},
+        )
 
     @classmethod
     def from_level_and_solution(cls, level: Level, solution: Solution) -> State:

--- a/chipwizard_sim/simulator.py
+++ b/chipwizard_sim/simulator.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from .models import *
 
 
@@ -52,12 +50,12 @@ def flood_power(state: State):
 
 def simulate_solution(level: Level, solution: Solution) -> SimulationResult:
     state = State.from_level_and_solution(level, solution)
-    states = [deepcopy(state)]
+    states = [state.copy()]
 
     is_error = False
 
     signal_results = {
-        loc: SignalResult(signal.name, signal.type, [], deepcopy(signal.values))
+        loc: SignalResult(signal.name, signal.type, [], list(signal.values))
         for loc, signal in level.signals.items()
     }
 
@@ -70,7 +68,7 @@ def simulate_solution(level: Level, solution: Solution) -> SimulationResult:
 
         flood_power(state)
 
-        substates = [deepcopy(state)]
+        substates = [state.copy()]
         while True:
             for _, cell in state.cells.items():
                 cell.update_gates()
@@ -81,8 +79,8 @@ def simulate_solution(level: Level, solution: Solution) -> SimulationResult:
             elif state in substates:
                 is_error = True
                 break
-            substates.append(deepcopy(state))
-        states.append(deepcopy(state))
+            substates.append(state.copy())
+        states.append(state.copy())
         for loc, signal in state.signals.items():
             signal_results[loc].values.append(signal.output_value)
 


### PR DESCRIPTION
This avoids a lot of extra work that deepcopy does by default, and
speeds up the simulations by around 4x on my machine.